### PR TITLE
Feature: Initialise skrollr at run stage

### DIFF
--- a/app/js/skrollr.js
+++ b/app/js/skrollr.js
@@ -63,8 +63,9 @@ angular.module("sn.skrollr", [])
                  */
                 init: function() {
 
-                    var skrollrInit = function skrollrInit(){
-                        _this.skrollrInstance = $window.skrollr.init(_this.config);
+                    var skrollrInit = function skrollrInit(config){
+                        var skrollrConfig = config ? config : _this.config;
+                        _this.skrollrInstance = $window.skrollr.init(skrollrConfig);
                         _this.hasBeenInitialised = true;
                         _this.serviceMethods.refresh();
                     };


### PR DESCRIPTION
To allow access to instances of angular services in config functions such as `keyframe`, it is necessary to  allow the config to be set at the run function of an angular module.
