### PR TITLE
Fix: package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,16 @@ Angular Skrollr wraps the skrollr.js library to provide a mechanisim for configu
 
 ## Install
 
+### using Bower
+
 ```
-bower install angular-skrollr
-bower install skrollr
+bower install --save angular-skrollr
+```
+
+### using NPM
+
+```
+npm install --save angular-skrollr
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
     "parallax",
     "directive"
   ],
+  "files": [
+    "app/js",
+    "dist",
+    "node_modules",
+    "CHANGELOG.md",
+    "README.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "skrollr": "~0.6.26"
   },

--- a/package.json
+++ b/package.json
@@ -18,10 +18,6 @@
     { "name": "James Warren", "email": "james@thisissoon.com" },
     { "name": "Kenny Sabir", "email": "kenny.sabir@agriwebb.com" }
   ],
-  "dependencies": {
-    "bower": "~1.3.12",
-    "grunt": "~0.4.5"
-  },
   "main": "dist/angular-skrollr.js",
   "keywords": [
     "angular",
@@ -29,7 +25,12 @@
     "parallax",
     "directive"
   ],
+  "dependencies": {
+    "skrollr": "~0.6.26"
+  },
   "devDependencies": {
+    "bower": "~1.3.12",
+    "grunt": "~0.4.5",
     "connect-livereload": "~0.5.0",
     "connect-modrewrite": "~0.7.9",
     "coveralls": "~2.11.2",


### PR DESCRIPTION
Limit files installed via `npm` to just what is needed and add `skrollr` as a dependancies  
